### PR TITLE
Update GitHub Pages link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ IT professionals to use when managing an NI SystemLink Server installation.
 ## Accessing Documentation
 
 The handbook is divided into chapters and published as HTML accessible at
-<https://ni.github.io/systemlink-operations-handbook/>.
+<https://operations.systemlink.io/>.
 
 The markdown and other supporting files used to generate the handbook are
 accessible within the [handbook directory](handbook).


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/systemlink-operations-handbook/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Updates the GitHub Pages link in the main README to <https://operations.systemlink.io/>.

### Why should this Pull Request be merged?

We have a CNAME set up to use a custom domain, so we should link to that instead of the default URL that then redirects to the correct link.

### What testing has been done?

Looked at the [rendered README](https://github.com/ni/systemlink-operations-handbook/tree/users/pspangle/readme-link) and followed the link.
