### PR TITLE
Write an introduction to the handbook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+.venv/
 site/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,12 +22,13 @@ for using [MkDocs](https://www.mkdocs.org):
 
 1. Download and [install Python](https://www.python.org/)
    (NI recommends 3.8 or later)
-2. (Optional) Create a virtual environment named `mkdocs` in the current
-   directory by running `python -m venv mkdocs`
-3. (Optional) To activate the created `mkdocs` virtual environment, change to
-   the `Scripts` sub-directory and run `activate`
-4. Upgrade pip by running `python -m pip install --upgrade pip`
-5. Install dependencies by running `pip install -r requirements.txt`
+2. (Optional) Create a virtual environment named `.venv` in the current
+   directory by running `python -m venv .venv`. Each time you open a new
+   command window, activate the environment before running `mkdocs` commands:
+    - Windows users: run `.venv\Scripts\activate`
+    - Linux or Mac users: run `source .venv/Scripts/activate`
+3. Upgrade pip by running `python -m pip install --upgrade pip`
+4. Install dependencies by running `pip install -r requirements.txt`
 
 For more information and installation options, see
 [MkDocs - Installation](https://www.mkdocs.org/#installation).

--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
 # SystemLink Operations Handbook
 
 This repository contains documentation, examples, and example config files for
-IT professionals to use when managing an NI SystemLink Server installation.
+IT professionals to use when managing an NI SystemLink Server installation
+beyond the basic configuration installed with SystemLink. For information about
+how to install and use a SystemLink server, see the
+[latest product manual on ni.com](https://www.ni.com/r/systemlinkmanual).
 
 ## Accessing Documentation
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # SystemLink Operations Handbook
 
 This repository contains documentation, examples, and example config files for
-IT professionals to use when managing an NI SystemLink Server installation
-beyond the basic configuration installed with SystemLink. For information about
+IT professionals to use when managing more advanced configurations of
+[NI SystemLink Server](https://www.ni.com/systemlink). For information about
 how to install and use a SystemLink server, see the
 [latest product manual on ni.com](https://www.ni.com/r/systemlinkmanual).
 

--- a/handbook/README.md
+++ b/handbook/README.md
@@ -3,10 +3,9 @@ title: Introduction
 ---
 
 The SystemLink Operations Handbook contains documentation, examples, and
-example config files for IT professionals to use when managing an
-[NI SystemLink Server](https://www.ni.com/systemlink) installation beyond the
-basic configuration installed with SystemLink. For information about how to
-install and use a SystemLink server, see the
+example config files for IT professionals to use when managing more advanced
+configurations of [NI SystemLink Server](https://www.ni.com/systemlink). For
+information about how to install and use a SystemLink server, see the
 [latest product manual on ni.com](https://www.ni.com/r/systemlinkmanual).
 Source and contributions for the handbook and example files can be found in the
 [systemlink-operations-handbook GitHub repository](https://github.com/ni/systemlink-operations-handbook).
@@ -16,9 +15,6 @@ product continues to evolve over time. Some chapters or examples may
 specify a version or range of versions of SystemLink that they apply to.
 
 ## Table of Contents
-
-The handbook is divided into chapters, listed in the navigation on the left
-side of the page. A brief description of each chapter is included below:
 
 - [Placeholder](placeholder) - a placeholder chapter that will be filled in
   later.

--- a/handbook/README.md
+++ b/handbook/README.md
@@ -1,11 +1,24 @@
 ---
 title: Introduction
-...
+---
 
-# NI SystemLink Operations Handbook
+The SystemLink Operations Handbook contains documentation, examples, and
+example config files for IT professionals to use when managing an
+[NI SystemLink Server](https://www.ni.com/systemlink) installation beyond the
+basic configuration installed with SystemLink. For information about how to
+install and use a SystemLink server, see the
+[latest product manual on ni.com](https://www.ni.com/r/systemlinkmanual).
+Source and contributions for the handbook and example files can be found in the
+[systemlink-operations-handbook GitHub repository](https://github.com/ni/systemlink-operations-handbook).
 
-Placeholder
+While the handbook is not specific to any version of SystemLink Server, the
+product continues to evolve over time. Some chapters or examples may
+specify a version or range of versions of SystemLink that they apply to.
 
-## Chapters
+## Table of Contents
 
-Placeholder
+The handbook is divided into chapters, listed in the navigation on the left
+side of the page. A brief description of each chapter is included below:
+
+- [Placeholder](placeholder) - a placeholder chapter that will be filled in
+  later.


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/systemlink-operations-handbook/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Fills in the introduction page for the handbook, clarifies in the top-level README that the handbook isn't a replacement for the product manual, and updates the CONTRIBUTING with a recommendation to use a .venv directory for the virtual environment.

### Why should this Pull Request be merged?

Adds the initial content instead of placeholder text.

### What testing has been done?

Looked at the rendered markdown files: [README.md](https://github.com/ni/systemlink-operations-handbook/tree/users/pspangle/intro) and [CONTRIBUTING.md](https://github.com/ni/systemlink-operations-handbook/blob/users/pspangle/intro/CONTRIBUTING.md). Followed the instructions for creating the .venv environment.

Viewed the page using `mkdocs serve`:

![image](https://user-images.githubusercontent.com/7519484/90185661-a9a3f800-dd7c-11ea-9b2e-6580d164a216.png)

