### PR TITLE
Upgrade dependencies to remove permalinks workaround

### DIFF
--- a/handbook/stylesheets/extra.css
+++ b/handbook/stylesheets/extra.css
@@ -88,31 +88,8 @@
   text-decoration: underline;
 }
 
-/* Permalinks to work around https://github.com/timvink/mkdocs-enumerate-headings-plugin/issues/23 */
-
-h1 .enumerate-heading-plugin,
-h2 .enumerate-heading-plugin,
-h3 .enumerate-heading-plugin,
-h4 .enumerate-heading-plugin {
-  display: none;
-}
-
-.md-typeset h1:hover .toclink:after,
-.md-typeset h2:hover .toclink:after,
-.md-typeset h3:hover .toclink:after,
-.md-typeset h4:hover .toclink:after,
-a.toclink:focus:after {
-  content: " ¶";
-  opacity: 0.6;
-}
-
-a.toclink {
-  color: #333;
+a.headerlink {
   text-decoration: none;
-}
-
-a.toclink:hover, a.toclink:focus {
-  color: #333;
 }
 
 /* Footer navigation */

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,8 +15,7 @@ markdown_extensions:
   - pymdownx.superfences
   - pymdownx.tabbed
   - toc:
-      # Use anchorlink instead of permalink to work around https://github.com/timvink/mkdocs-enumerate-headings-plugin/issues/23
-      anchorlink: true
+      permalink: true
       marker: ''
 
 plugins:

--- a/overrides/partials/nav-item.html
+++ b/overrides/partials/nav-item.html
@@ -1,5 +1,5 @@
 {#-
-  Customized from v5.5.6 mkdocs-material.
+  Customized from v5.5.12 mkdocs-material.
 -#}
 {% set class = "md-nav__item" %}
 {% if nav_item.active %}
@@ -14,15 +14,11 @@
     {% endif %}
     <label class="md-nav__link" for="{{ path }}">
       {{ chapter }}. {{ nav_item.title }}
-      <span class="md-nav__icon md-icon">
-        {% include ".icons/material/chevron-right.svg" %}
-      </span>
+      <span class="md-nav__icon md-icon"></span>
     </label>
     <nav class="md-nav" aria-label="{{ nav_item.title }}" data-md-level="{{ level }}">
       <label class="md-nav__title" for="{{ path }}">
-        <span class="md-nav__icon md-icon">
-          {% include ".icons/material/arrow-left.svg" %}
-        </span>
+        <span class="md-nav__icon md-icon"></span>
         {{ chapter }}. {{ nav_item.title }}
       </label>
       <ul class="md-nav__list" data-md-scrollfix>
@@ -45,9 +41,7 @@
     {% if toc | first is defined %}
       <label class="md-nav__link md-nav__link--active" for="__toc">
         {{ chapter }}. {{ nav_item.title }}
-        <span class="md-nav__icon md-icon">
-          {% include ".icons/material/table-of-contents.svg" %}
-        </span>
+        <span class="md-nav__icon md-icon"></span>
       </label>
     {% endif %}
     <a href="{{ nav_item.url | url }}" title="{{ nav_item.title | striptags }}" class="md-nav__link md-nav__link--active">

--- a/overrides/partials/nav.html
+++ b/overrides/partials/nav.html
@@ -1,5 +1,5 @@
 {#-
-  Customized from v5.5.6 mkdocs-material.
+  Customized from v5.5.12 mkdocs-material.
 -#}
 <nav class="md-nav md-nav--primary" aria-label="{{ lang.t('nav.title') }}" data-md-level="0">
   <label class="md-nav__title" for="__drawer">

--- a/overrides/partials/toc.html
+++ b/overrides/partials/toc.html
@@ -1,5 +1,5 @@
 {#-
-  Customized from v5.5.6 mkdocs-material.
+  Customized from v5.5.12 mkdocs-material.
 -#}
 {% import "partials/language.html" as lang with context %}
 <nav class="md-nav md-nav--secondary" aria-label="{{ lang.t('toc.title') }}">
@@ -9,9 +9,7 @@
   {% endif %}
   {% if toc | first is defined %}
     <label class="md-nav__title" for="__toc">
-      <span class="md-nav__icon md-icon">
-        {% include ".icons/material/arrow-left.svg" %}
-      </span>
+      <span class="md-nav__icon md-icon"></span>
       {{ page.title }}
     </label>
     <ul class="md-nav__list" data-md-scrollfix>

--- a/patches/README.md
+++ b/patches/README.md
@@ -5,7 +5,7 @@ This directory contains patches for the files contained in the MkDocs theme
 the theme in the future without manually trying to resolve the differences
 between the originals and our custom files.
 
-The patches are currently based on v5.5.6 of mkdocs-material. Originals can be
+The patches are currently based on v5.5.12 of mkdocs-material. Originals can be
 found in your Python environment's `Lib/site-packages/material` directory.
 
 ## Modifications

--- a/patches/partials/nav-item.html.patch
+++ b/patches/partials/nav-item.html.patch
@@ -1,39 +1,35 @@
---- .venv/Lib/site-packages/material/partials/nav-item.html	2020-08-14 13:12:49.726377200 -0500
-+++ overrides/partials/nav-item.html	2020-08-14 12:57:48.639544200 -0500
+--- .venv/Lib/site-packages/material/partials/nav-item.html	2020-09-15 09:26:54.102101300 -0500
++++ overrides/partials/nav-item.html	2020-09-15 10:21:31.937657300 -0500
 @@ -1,5 +1,5 @@
  {#-
 -  This file was automatically generated - do not edit
-+  Customized from v5.5.6 mkdocs-material.
++  Customized from v5.5.12 mkdocs-material.
  -#}
  {% set class = "md-nav__item" %}
  {% if nav_item.active %}
-@@ -13,7 +13,7 @@
+@@ -13,13 +13,13 @@
        <input class="md-nav__toggle md-toggle" data-md-toggle="{{ path }}" type="checkbox" id="{{ path }}">
      {% endif %}
      <label class="md-nav__link" for="{{ path }}">
 -      {{ nav_item.title }}
 +      {{ chapter }}. {{ nav_item.title }}
-       <span class="md-nav__icon md-icon">
-         {% include ".icons/material/chevron-right.svg" %}
-       </span>
-@@ -23,7 +23,7 @@
-         <span class="md-nav__icon md-icon">
-           {% include ".icons/material/arrow-left.svg" %}
-         </span>
+       <span class="md-nav__icon md-icon"></span>
+     </label>
+     <nav class="md-nav" aria-label="{{ nav_item.title }}" data-md-level="{{ level }}">
+       <label class="md-nav__title" for="{{ path }}">
+         <span class="md-nav__icon md-icon"></span>
 -        {{ nav_item.title }}
 +        {{ chapter }}. {{ nav_item.title }}
        </label>
        <ul class="md-nav__list" data-md-scrollfix>
          {% set base = path %}
-@@ -44,14 +44,14 @@
+@@ -40,12 +40,12 @@
      {% endif %}
      {% if toc | first is defined %}
        <label class="md-nav__link md-nav__link--active" for="__toc">
 -        {{ nav_item.title }}
 +        {{ chapter }}. {{ nav_item.title }}
-         <span class="md-nav__icon md-icon">
-           {% include ".icons/material/table-of-contents.svg" %}
-         </span>
+         <span class="md-nav__icon md-icon"></span>
        </label>
      {% endif %}
      <a href="{{ nav_item.url | url }}" title="{{ nav_item.title | striptags }}" class="md-nav__link md-nav__link--active">
@@ -42,7 +38,7 @@
      </a>
      {% if toc | first is defined %}
        {% include "partials/toc.html" %}
-@@ -60,7 +60,7 @@
+@@ -54,7 +54,7 @@
  {% else %}
    <li class="{{ class }}">
      <a href="{{ nav_item.url | url }}" title="{{ nav_item.title | striptags }}" class="md-nav__link">

--- a/patches/partials/nav.html.patch
+++ b/patches/partials/nav.html.patch
@@ -1,9 +1,9 @@
---- .venv/Lib/site-packages/material/partials/nav.html	2020-08-14 13:11:10.235279300 -0500
-+++ overrides/partials/nav.html	2020-08-14 12:54:13.788035700 -0500
+--- .venv/Lib/site-packages/material/partials/nav.html	2020-09-15 09:26:50.699516200 -0500
++++ overrides/partials/nav.html	2020-09-15 10:21:28.426720700 -0500
 @@ -1,12 +1,9 @@
  {#-
 -  This file was automatically generated - do not edit
-+  Customized from v5.5.6 mkdocs-material.
++  Customized from v5.5.12 mkdocs-material.
  -#}
  <nav class="md-nav md-nav--primary" aria-label="{{ lang.t('nav.title') }}" data-md-level="0">
    <label class="md-nav__title" for="__drawer">

--- a/patches/partials/toc.html.patch
+++ b/patches/partials/toc.html.patch
@@ -1,16 +1,16 @@
---- .venv/Lib/site-packages/material/partials/toc.html	2020-08-14 13:13:40.932600300 -0500
-+++ overrides/partials/toc.html	2020-08-14 13:00:39.101758500 -0500
+--- .venv/Lib/site-packages/material/partials/toc.html	2020-09-15 09:26:57.279601300 -0500
++++ overrides/partials/toc.html	2020-09-15 10:21:35.509665400 -0500
 @@ -1,5 +1,5 @@
  {#-
 -  This file was automatically generated - do not edit
-+  Customized from v5.5.6 mkdocs-material.
++  Customized from v5.5.12 mkdocs-material.
  -#}
  {% import "partials/language.html" as lang with context %}
  <nav class="md-nav md-nav--secondary" aria-label="{{ lang.t('toc.title') }}">
-@@ -12,7 +12,7 @@
-       <span class="md-nav__icon md-icon">
-         {% include ".icons/material/arrow-left.svg" %}
-       </span>
+@@ -10,7 +10,7 @@
+   {% if toc | first is defined %}
+     <label class="md-nav__title" for="__toc">
+       <span class="md-nav__icon md-icon"></span>
 -      {{ lang.t("toc.title") }}
 +      {{ page.title }}
      </label>

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,9 +12,9 @@ Markdown==3.2.2
 MarkupSafe==1.1.1
 mkdocs==1.1.2
 mkdocs-awesome-pages-plugin==2.2.1
-mkdocs-enumerate-headings-plugin==0.4.1
-mkdocs-git-revision-date-localized-plugin==0.7
-mkdocs-material==5.5.6
+mkdocs-enumerate-headings-plugin==0.4.3
+mkdocs-git-revision-date-localized-plugin==0.7.1
+mkdocs-material==5.5.12
 mkdocs-material-extensions==1.0
 nltk==3.5
 Pygments==2.6.1


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/systemlink-operations-handbook/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Updates to latest dependencies and remove workaround for timvink/mkdocs-enumerate-headings-plugin#23. I went ahead and upgraded to the latest mkdocs-material as well, which included some minor accessibility fixes but required rebasing our patches.

### Why should this Pull Request be merged?

Provides cleaner permalinks and less hackyness.

### What testing has been done?

Built the documentation and verified the updated behavior.

Hover over heading:
![image](https://user-images.githubusercontent.com/7519484/93233862-3148a200-f741-11ea-8743-293a7befb22a.png)
Hover over link:
![image](https://user-images.githubusercontent.com/7519484/93233900-3dccfa80-f741-11ea-850a-54b98fb803eb.png)

