### PR TITLE
Add section outlining configuration of AUTH_OIDC_CACHE_ENTRY_SIZE

### DIFF
--- a/handbook/openid-connect/openid-connect.md
+++ b/handbook/openid-connect/openid-connect.md
@@ -317,17 +317,16 @@ The following sources can be used to troubleshoot a failed connection.
 
 **Returned Claims:** See [**Viewing Claims Returned by a Provider**](#viewing-claims-returned-by-a-provider).
 
-### Cache Shm Entry Size Max
+### Cache Entry Size
 
-If an "Internal Server Error" is encountered when attempting to log in, this may be an issue with the defined `OIDCCacheShmEntrySizeMax`. You can verify this is the issue by searching the NI Web Server logs for the following entries
+The OpenID Connect module stores information in a shared memory cache. If a cache entry is too large, users will see an "Internal Server Error" when attempting to log in, and the NI Web Server logs will contain the following entries
 ```
     oidc_cache_shm_set: could not store value since value size is too large
     oidc_cache_set: could NOT store X bytes in shm cache backend for key Y
 ```
 To resolve this issue
 
-- Open the following file in a text editor run as Administrator `C:\Program Files\National Instruments\Shared\Web Server\conf\defines.d\50_mod_auth_openidc-defines.conf.defaults`
+- Open the following file in a text editor run as Administrator `C:\Program Files\National Instruments\Shared\Web Server\conf\defines.d\50_mod_auth_openidc-defines.conf`
 - Find the line `Define AUTH_OIDC_CACHE_ENTRY_SIZE 66065`
-- Modify `66065` to a number larger than X, where X is the required size of the shm cache entry specified in the error log
-    - It is suggested to follow the [documentation](https://github.com/zmartzone/mod_auth_openidc/blob/master/auth_openidc.conf#L600https://github.com/zmartzone/mod_auth_openidc/blob/master/auth_openidc.conf#L600) when modifying this number
+- Modify `66065` to a number larger than X, where X is the required size of the cache entry specified in the error log
 - Restart the NI Web Server from the `Control` tab of the NI Web Server Configuration application

--- a/handbook/openid-connect/openid-connect.md
+++ b/handbook/openid-connect/openid-connect.md
@@ -319,14 +319,19 @@ The following sources can be used to troubleshoot a failed connection.
 
 ### Cache Entry Size
 
-The OpenID Connect module stores information in a shared memory cache. If a cache entry is too large, users will see an "Internal Server Error" when attempting to log in, and the NI Web Server logs will contain the following entries
-```
+The OpenID Connect module stores information in a shared memory cache. If a cache entry is too large, users will see an "Internal Server Error" when attempting to log in. This typically occurs when you are returning a large number of claims or claims with large values.
+
+!!! note "Example error logs"
+    When this happens, the NI Web Server error logs will contain entries like the following:
+
+    ```text
     oidc_cache_shm_set: could not store value since value size is too large
     oidc_cache_set: could NOT store X bytes in shm cache backend for key Y
-```
-To resolve this issue
+    ```
+
+To resolve this issue:
 
 - Open the following file in a text editor run as Administrator `C:\Program Files\National Instruments\Shared\Web Server\conf\defines.d\50_mod_auth_openidc-defines.conf`
-- Find the line `Define AUTH_OIDC_CACHE_ENTRY_SIZE 66065`
-- Modify `66065` to a number larger than X, where X is the required size of the cache entry specified in the error log
+- Find the line starting with `Define AUTH_OIDC_CACHE_ENTRY_SIZE`
+- Modify the number at the end to a number larger than X, where X is the required size of the cache entry specified in the error log
 - Restart the NI Web Server from the `Control` tab of the NI Web Server Configuration application

--- a/handbook/openid-connect/openid-connect.md
+++ b/handbook/openid-connect/openid-connect.md
@@ -319,14 +319,15 @@ The following sources can be used to troubleshoot a failed connection.
 
 ### Cache Shm Entry Size Max
 
-If an "Internal Server Error" is encountered when attempting to log in, this may be an issue with the defined `OIDCCacheShmEntrySizeMax`. You can verify this is the issue by searching the NI Web Server logs for the following entries:
+If an "Internal Server Error" is encountered when attempting to log in, this may be an issue with the defined `OIDCCacheShmEntrySizeMax`. You can verify this is the issue by searching the NI Web Server logs for the following entries
 ```
     oidc_cache_shm_set: could not store value since value size is too large
     oidc_cache_set: could NOT store X bytes in shm cache backend for key Y
 ```
 To resolve this issue
+
 - Open the following file in a text editor run as Administrator `C:\Program Files\National Instruments\Shared\Web Server\conf\defines.d\50_mod_auth_openidc-defines.conf.defaults`
 - Find the line `Define AUTH_OIDC_CACHE_ENTRY_SIZE 66065`
-- Modify `66065` to a number larger than X, where X is the required size of the shm cache entry specified in the error log entry
-    - It is suggested to follow the [documentation](https://github.com/zmartzone/mod_auth_openidc/blob/master/auth_openidc.conf#L600https://github.com/zmartzone/mod_auth_openidc/blob/master/auth_openidc.conf#L600) when changing this number
+- Modify `66065` to a number larger than X, where X is the required size of the shm cache entry specified in the error log
+    - It is suggested to follow the [documentation](https://github.com/zmartzone/mod_auth_openidc/blob/master/auth_openidc.conf#L600https://github.com/zmartzone/mod_auth_openidc/blob/master/auth_openidc.conf#L600) when modifying this number
 - Restart the NI Web Server from the `Control` tab of the NI Web Server Configuration application

--- a/handbook/openid-connect/openid-connect.md
+++ b/handbook/openid-connect/openid-connect.md
@@ -316,3 +316,17 @@ The following sources can be used to troubleshoot a failed connection.
     SystemLink uses log rotation therefore the latest logs may be in one of the numbered `error.log` files.
 
 **Returned Claims:** See [**Viewing Claims Returned by a Provider**](#viewing-claims-returned-by-a-provider).
+
+### Cache Shm Entry Size Max
+
+If an "Internal Server Error" is encountered when attempting to log in, this may be an issue with the defined `OIDCCacheShmEntrySizeMax`. You can verify this is the issue by searching the NI Web Server logs for the following entries:
+```
+    oidc_cache_shm_set: could not store value since value size is too large
+    oidc_cache_set: could NOT store X bytes in shm cache backend for key Y
+```
+To resolve this issue
+- Open the following file in a text editor run as Administrator `C:\Program Files\National Instruments\Shared\Web Server\conf\defines.d\50_mod_auth_openidc-defines.conf.defaults`
+- Find the line `Define AUTH_OIDC_CACHE_ENTRY_SIZE 66065`
+- Modify `66065` to a number larger than X, where X is the required size of the shm cache entry specified in the error log entry
+    - It is suggested to follow the [documentation](https://github.com/zmartzone/mod_auth_openidc/blob/master/auth_openidc.conf#L600https://github.com/zmartzone/mod_auth_openidc/blob/master/auth_openidc.conf#L600) when changing this number
+- Restart the NI Web Server from the `Control` tab of the NI Web Server Configuration application


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/systemlink-operations-handbook/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Outlines how to modify the AUTH_OIDC_CACHE_ENTRY_SIZE. This may be required for users that have large claims.

### Why should this Pull Request be merged?

The error that results in needing to modify this configuration makes OIDC login unusable for some users. This configuration is not yet surfaced in a configuration utility and requires manual config file modification.

### What testing has been done?

- Verified the steps outlined fixes the issue
- Verified formatting by running mkdocs locally
