### PR TITLE
Fix path to activate script on Linux

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ for using [MkDocs](https://www.mkdocs.org):
    directory by running `python -m venv .venv`. Each time you open a new
    command window, activate the environment before running `mkdocs` commands:
     - Windows users: run `.venv\Scripts\activate`
-    - Linux or Mac users: run `source .venv/Scripts/activate`
+    - Linux or Mac users: run `source .venv/bin/activate`
 3. Upgrade pip by running `python -m pip install --upgrade pip`
 4. Install dependencies by running `pip install -r requirements.txt`
 


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/systemlink-operations-handbook/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

The path to the activate script was incorrect for Linux

### Why should this Pull Request be merged?

Avoid confusion during developer setup

### What testing has been done?

Viewed the change in the rendered file on github
