### PR TITLE
Fix simple typo in OpenID Connect claim mapping documentation

### DIFF
--- a/handbook/openid-connect/openid-connect.md
+++ b/handbook/openid-connect/openid-connect.md
@@ -247,7 +247,7 @@ You can also view claims returned by a particular user by modifying the httpd co
 4. Go to `[protocol]://[systemlink-dns]/login/openidc-redirect?info=html` or `[protocol]://[systemlink-dns]/login/openidc-redirect?info=json` to view user claims.
 
 !!! note ""
-    An example `50_mod_auth_openidc-defines.conf` modified to expose user claims. You must be logged via OpenID Connect to receive data this endpoint.
+    An example `50_mod_auth_openidc-defines.conf` modified to expose user claims. You must be logged via OpenID Connect to receive data from this endpoint.
     ```conf
     #
     # Defined OpenID-Connect configuration for the Windows Apache installation.


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/systemlink-operations-handbook/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Fix a typo in the documentation for mapping OpenID Connect claims to workspace roles.

### Why should this Pull Request be merged?

Fixes a typo.

### What testing has been done?

Verified changes locally.
