### PR TITLE
Fix typo in OIDC documentation

### DIFF
--- a/handbook/openid-connect/openid-connect.md
+++ b/handbook/openid-connect/openid-connect.md
@@ -295,11 +295,11 @@ You can also view claims returned by a particular user by modifying the httpd co
     Define AUTH_OIDC_ENABLE_CLAIM_INFO
     ```
 
-If the provider is https with a certificate signed by a CA not included in the NI-CURL CA bundle (`C:\Program Files\National Instruments\Shared\nicurl\ca-bundle.crt`), then the `AUTH_OIDC_PROVIDER_DIR` define in `50_mod_auth_openidc-defines.conf` must to be updated to point to a CA bundle containing the provider's CA. The path can be absolute, or relative to `C:\Program Files\National Instruments\Shared\Web Server`.
+If the provider is https with a certificate signed by a CA not included in the NI-CURL CA bundle (`C:\Program Files\National Instruments\Shared\nicurl\ca-bundle.crt`), then the `AUTH_OIDC_BUNDLE` define in `50_mod_auth_openidc-defines.conf` must to be updated to point to a CA bundle containing the provider's CA. The path can be absolute, or relative to `C:\Program Files\National Instruments\Shared\Web Server`.
 
 ### Mapping Claims to SystemLink Roles
 
-Claims are returned as a JSON object.  
+Claims are returned as a JSON object.
 
 !!! note ""
     Example response from `userinfo_endpoint`. Use any of these claims to a map a user to a role in a workspace.


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/systemlink-operations-handbook/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

The OIDC documentation was referencing the wrong config token in 50_mod_auth_openidc-defines.conf. Trevor identified this issue. I'm posting his requested fix.

### Why should this Pull Request be merged?

Corrects the documentation.

### What testing has been done?

N/A
