### PR TITLE
Make which role is needed for mongo more clear.

### DIFF
--- a/handbook/data-stores/mongodb.md
+++ b/handbook/data-stores/mongodb.md
@@ -14,6 +14,8 @@ Before you configure a remote MongoDB instance to use with SystemLink, ensure yo
 
 !!!important
     Due to a bug in a third-party MongoDB driver, SystemLink cannot connect to MongoDB instances where the MongoDB username contains either the `-` or the `_` character.
+    
+!!!important The `readWrite` role does not have the required `createCollection` privilege.
 
 ## Single Node vs Multi Node MongoDB Deployments
 

--- a/handbook/data-stores/mongodb.md
+++ b/handbook/data-stores/mongodb.md
@@ -10,7 +10,7 @@ Before you configure a remote MongoDB instance to use with SystemLink, ensure yo
 
 - A server running SystemLink 2021 R1 or greater. Refer to [Installing and Configuring SystemLink Server and Clients](https://www.ni.com/documentation/en/systemlink/latest/setup/configuring-systemlink-server-clients/) for the basics of setting up a SystemLink server.
 - A standalone server running MongoDB, multiple servers hosting a MongoDB replica set, or a MongoDB Atlas Account
-- A user with the `readWriteAnyDatabase` or similar role. Refer to [Role-Based Access Control](https://docs.mongodb.com/manual/core/authorization/) for details. You reference this user in the MongoDB connection fields or connection string in **NI SystemLink Server Configuration**.
+- A user with the `readWriteAnyDatabase` role. This is NOT the same as a user with the `readWrite` role because the user will need the `createCollection` privilege for new collections. Refer to [Role-Based Access Control](https://docs.mongodb.com/manual/core/authorization/) for details. You reference this user in the MongoDB connection fields or connection string in **NI SystemLink Server Configuration**.
 
 !!!important
     Due to a bug in a third-party MongoDB driver, SystemLink cannot connect to MongoDB instances where the MongoDB username contains either the `-` or the `_` character.

--- a/handbook/data-stores/mongodb.md
+++ b/handbook/data-stores/mongodb.md
@@ -10,7 +10,7 @@ Before you configure a remote MongoDB instance to use with SystemLink, ensure yo
 
 - A server running SystemLink 2021 R1 or greater. Refer to [Installing and Configuring SystemLink Server and Clients](https://www.ni.com/documentation/en/systemlink/latest/setup/configuring-systemlink-server-clients/) for the basics of setting up a SystemLink server.
 - A standalone server running MongoDB, multiple servers hosting a MongoDB replica set, or a MongoDB Atlas Account
-- A user with the `readWriteAnyDatabase` role. The user must have the `createCollection` privilege and be able to create new databases. Refer to [Role-Based Access Control](https://docs.mongodb.com/manual/core/authorization/) for details. .
+- A user with the `readWriteAnyDatabase` role. The user must have the `createCollection` privilege and be able to create new databases. Refer to [Role-Based Access Control](https://docs.mongodb.com/manual/core/authorization/) for details.
 
 !!!important
     Due to a bug in a third-party MongoDB driver, SystemLink cannot connect to MongoDB instances where the MongoDB username contains either the `-` or the `_` character.

--- a/handbook/data-stores/mongodb.md
+++ b/handbook/data-stores/mongodb.md
@@ -10,7 +10,7 @@ Before you configure a remote MongoDB instance to use with SystemLink, ensure yo
 
 - A server running SystemLink 2021 R1 or greater. Refer to [Installing and Configuring SystemLink Server and Clients](https://www.ni.com/documentation/en/systemlink/latest/setup/configuring-systemlink-server-clients/) for the basics of setting up a SystemLink server.
 - A standalone server running MongoDB, multiple servers hosting a MongoDB replica set, or a MongoDB Atlas Account
-- A user with the `readWriteAnyDatabase` role. This is NOT the same as a user with the `readWrite` role because the user will need the `createCollection` privilege for new top level databases, not just creating collections within existing databases. Refer to [Role-Based Access Control](https://docs.mongodb.com/manual/core/authorization/) for details. You reference this user in the MongoDB connection fields or connection string in **NI SystemLink Server Configuration**.
+- A user with the `readWriteAnyDatabase` role. The user must have the `createCollection` privilege and be able to create new databases. Refer to [Role-Based Access Control](https://docs.mongodb.com/manual/core/authorization/) for details. .
 
 !!!important
     Due to a bug in a third-party MongoDB driver, SystemLink cannot connect to MongoDB instances where the MongoDB username contains either the `-` or the `_` character.

--- a/handbook/data-stores/mongodb.md
+++ b/handbook/data-stores/mongodb.md
@@ -10,7 +10,7 @@ Before you configure a remote MongoDB instance to use with SystemLink, ensure yo
 
 - A server running SystemLink 2021 R1 or greater. Refer to [Installing and Configuring SystemLink Server and Clients](https://www.ni.com/documentation/en/systemlink/latest/setup/configuring-systemlink-server-clients/) for the basics of setting up a SystemLink server.
 - A standalone server running MongoDB, multiple servers hosting a MongoDB replica set, or a MongoDB Atlas Account
-- A user with the `readWriteAnyDatabase` role. This is NOT the same as a user with the `readWrite` role because the user will need the `createCollection` privilege for new collections. Refer to [Role-Based Access Control](https://docs.mongodb.com/manual/core/authorization/) for details. You reference this user in the MongoDB connection fields or connection string in **NI SystemLink Server Configuration**.
+- A user with the `readWriteAnyDatabase` role. This is NOT the same as a user with the `readWrite` role because the user will need the `createCollection` privilege for new top level databases, not just creating collections within existing databases. Refer to [Role-Based Access Control](https://docs.mongodb.com/manual/core/authorization/) for details. You reference this user in the MongoDB connection fields or connection string in **NI SystemLink Server Configuration**.
 
 !!!important
     Due to a bug in a third-party MongoDB driver, SystemLink cannot connect to MongoDB instances where the MongoDB username contains either the `-` or the `_` character.


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/systemlink-operations-handbook/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Update the mongodb documentation to be more clear about which role is needed for external mongo db user.

### Why should this Pull Request be merged?

To reduce ambiguity in our documentation.

### What testing has been done?

The `readWrite` role doesn't work because it can't create new top level collections, our documentation didn't say it does, but it could have been more clear about the importance of `AnyDatabase`
