### PR TITLE
OIDC requires advanced server

### DIFF
--- a/handbook/openid-connect/openid-connect.md
+++ b/handbook/openid-connect/openid-connect.md
@@ -6,6 +6,8 @@ You can configure SystemLink to use OpenID Connect to authorize users. This enab
 
 - A server running SystemLink 2020R4 or greater. Refer to [Installing and Configuring SystemLink Server and Clients](https://www.ni.com/documentation/en/systemlink/latest/setup/configuring-systemlink-server-clients/) for the basics of setting up a SystemLink server
 
+- An active Advanced Server license for the SystemLink server
+
 - A DNS name for the SystemLink server
 
 - SystemLink login with the **Server Administrator** role

--- a/handbook/openid-connect/openid-connect.md
+++ b/handbook/openid-connect/openid-connect.md
@@ -6,7 +6,7 @@ You can configure SystemLink to use OpenID Connect to authorize users. This enab
 
 - A server running SystemLink 2020R4 or greater. Refer to [Installing and Configuring SystemLink Server and Clients](https://www.ni.com/documentation/en/systemlink/latest/setup/configuring-systemlink-server-clients/) for the basics of setting up a SystemLink server
 
-- An active Advanced Server license for the SystemLink server. If the license is inactive or expires, users will be able to log in with OpenID Connect, but they will not have any permissions and will see a blank page after log in.
+- An active Advanced Server license for the SystemLink server. If the license is inactive or expires, users will be able to log in with OpenID Connect, but they will not have any permissions and will see a blank page.
 
 - A DNS name for the SystemLink server
 

--- a/handbook/openid-connect/openid-connect.md
+++ b/handbook/openid-connect/openid-connect.md
@@ -6,7 +6,7 @@ You can configure SystemLink to use OpenID Connect to authorize users. This enab
 
 - A server running SystemLink 2020R4 or greater. Refer to [Installing and Configuring SystemLink Server and Clients](https://www.ni.com/documentation/en/systemlink/latest/setup/configuring-systemlink-server-clients/) for the basics of setting up a SystemLink server
 
-- An active Advanced Server license for the SystemLink server
+- An active Advanced Server license for the SystemLink server. If the license is inactive or expires, users will be able to log in with OpenID Connect, but they will not have any permissions and will see a blank page after log in.
 
 - A DNS name for the SystemLink server
 


### PR DESCRIPTION
License requirement was missing from the Assumptions and Perquisites for SSO.

- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/systemlink-operations-handbook/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Add the license requirement to the Assumptions And Prerequisites section on the Single Sign-on with OpenID Connect page

### Why should this Pull Request be merged?

There were multiple recent questions about why OIDC wasn't working which turned out to be the license.

### What testing has been done?

PR action
